### PR TITLE
Potential fix for code scanning alert no. 1: Query built from user-controlled sources

### DIFF
--- a/src/main/java/SQLInjectionExample.java
+++ b/src/main/java/SQLInjectionExample.java
@@ -5,16 +5,18 @@ import javax.servlet.http.HttpServletResponse;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 
 public class SQLInjectionExample extends HttpServlet {
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException {
         try {
             Connection con = DriverManager.getConnection("jdbc:mysql://localhost:3306/db");
 
-            String query = "SELECT * FROM users WHERE username = '" + request.getParameter("username") + "';";
-            Statement stmt = con.createStatement();
-
-            stmt.executeQuery(query);
+            String query = "SELECT * FROM users WHERE username = ?";
+            PreparedStatement pstmt = con.prepareStatement(query);
+            pstmt.setString(1, request.getParameter("username"));
+            ResultSet rs = pstmt.executeQuery();
         } catch (Exception e) {
             throw new ServletException(e);
         }


### PR DESCRIPTION
Potential fix for [https://github.com/antonychiu2/codeql-mobb-fixer-integration/security/code-scanning/1](https://github.com/antonychiu2/codeql-mobb-fixer-integration/security/code-scanning/1)

In general, the problem is fixed by avoiding SQL string concatenation with user input and instead using `PreparedStatement` with parameter placeholders (`?`) and binding user values with the appropriate setter methods (`setString`, `setInt`, etc.). This lets the JDBC driver handle escaping and ensures user input is treated as data, not executable SQL.

For this specific snippet, the best fix is:

- Replace the string-concatenated query with a parameterized query:  
  From:  
  `"SELECT * FROM users WHERE username = '" + request.getParameter("username") + "';"`
  To:  
  `"SELECT * FROM users WHERE username = ?"`
- Replace `Statement` with `PreparedStatement`.
- Bind `request.getParameter("username")` using `preparedStatement.setString(1, ...)`.
- Execute the query using `executeQuery()` with no SQL string argument.
- Add imports for `java.sql.PreparedStatement` and `java.sql.ResultSet` (if we choose to capture the result; even if not strictly needed, importing `PreparedStatement` is required).

All changes must be within `src/main/java/SQLInjectionExample.java`. Concretely:

- Add a `PreparedStatement` import at the top.
- Optionally add `ResultSet` import if we store the results (even if the example ignores them, using `ResultSet` is realistic and may avoid unused-result warnings if code is later expanded).
- In `doGet`, after obtaining the `Connection`, define a parameterized query string, create a `PreparedStatement`, set the username parameter, and call `executeQuery()` on the prepared statement.
- Remove the old `String query` definition and `Statement` usage.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
